### PR TITLE
added lazy loading to embedded YouTube videos

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -22,3 +22,60 @@ html, body {
 #youtube-listing-wrapper {
     height: 50vh;
 }
+.youtube {
+    background-color: #000;
+    margin-bottom: 30px;
+    position: relative;
+    padding-top: 56.25%;
+    overflow: hidden;
+    cursor: pointer;
+}
+.youtube img {
+    width: 100%;
+    top: -16.84%;
+    left: 0;
+    opacity: 0.7;
+}
+.youtube .play-button {
+    width: 90px;
+    height: 60px;
+    background-color: #333;
+    box-shadow: 0 0 30px rgba( 0,0,0,0.6 );
+    z-index: 1;
+    opacity: 0.8;
+    border-radius: 6px;
+}
+.youtube .play-button:before {
+    content: "";
+    border-style: solid;
+    border-width: 15px 0 15px 26.0px;
+    border-color: transparent transparent transparent #fff;
+}
+.youtube img,
+.youtube .play-button {
+    cursor: pointer;
+}
+.youtube img,
+.youtube iframe,
+.youtube .play-button,
+.youtube .play-button:before,
+.youtube .video-title {
+    position: absolute;
+}
+.youtube .play-button,
+.youtube .play-button:before {
+    top: 50%;
+    left: 50%;
+    transform: translate3d( -50%, -50%, 0 );
+}
+.youtube .video-title {
+    top: 10px;
+    left: 10px;
+    color: #fff;
+}
+.youtube iframe {
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -83,6 +83,9 @@ $(document).ready(function(){
     }
     function youTubify(searchTerm){
         console.log(searchTerm);
+        if ($('#youtubebox').hasClass('slick-slider')) {
+            $('#youtubebox').slick('unslick');
+        }
         // var youTubeQuery;
         try {
             var youTubeQuery = searchTerm.definition;
@@ -101,19 +104,44 @@ $(document).ready(function(){
             // console.log(response);
             
             var results = response.items;
+            console.log(results);
             var videoIds = [];
     
             for (var i = 0; i < results.length; i++) {
                 //div to hold video 
-                videoIds.push(results[i].id.videoId);
+                console.log(results[i].snippet.title)
+                videoIds.push({
+                    id: results[i].id.videoId,
+                    title: results[i].snippet.title,
+                    img: results[i].snippet.thumbnails.high.url
+                });
             }
             // console.log(videoIds);
 
+
+            var youTubeWrapper;
+            var playButton;
+            var imageThumb;
+            var title;
+            var videoId;
             for (var i = 0; i < videoIds.length; i++) {
-                var youTubeWrapper = $("<div>");
-                var video = '<iframe width="560" height="315" src="https://www.youtube.com/embed/' + videoIds[i] + '" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>';
-                // console.log(videoIds[i]);
-                youTubeWrapper.html(video);
+                videoId = videoIds[i].id;
+                youTubeWrapper = $("<div>");
+                playButton = $('<div>');
+                imageThumb = $('<img>');
+                title = $('<div>');
+                title.addClass('video-title');
+                title.text(videoIds[i].title);
+                imageThumb.attr('src', videoIds[i].img);
+                youTubeWrapper.addClass('youtube');
+                youTubeWrapper.attr('data-id',videoId);
+                playButton.addClass('play-button');
+                youTubeWrapper.append(playButton);
+                youTubeWrapper.append(imageThumb);
+                youTubeWrapper.append(title);
+                // var video = '<iframe width="560" height="315" src="https://www.youtube.com/embed/' + videoIds[i] + '" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>';
+                // // console.log(videoIds[i]);
+                // youTubeWrapper.html(video);
                 // console.log(youTubeWrapper);
                 $("#youtubebox").append(youTubeWrapper);
             }
@@ -161,6 +189,13 @@ $(document).ready(function(){
         setTimeout(function(){
             scrollTo('#youtubebox');
         });
+    });
+    $(document).on('click','.youtube',function(){
+        var iframe = $('<iframe>');
+        var source = "https://www.youtube.com/embed/"+ $(this).attr('data-id') +"?rel=0&showinfo=0&autoplay=1";
+        iframe.attr('src',source);
+        $(this).html('');
+        $(this).append(iframe);
     });
 });
 


### PR DESCRIPTION
We had some terrible loading times when we were loading all the embedded YouTube videos at once. This change creates thumbnail images that look like YouTube video thumbnails. When you click one of the thumbnails - that's when the video starts loading. This method has us down to ~20 HTTP requests when you hit 'send', rather than >150 requests